### PR TITLE
add annovar outputs to analyses move script

### DIFF
--- a/scripts/cpg_cromwell/move_analysis_outs.py
+++ b/scripts/cpg_cromwell/move_analysis_outs.py
@@ -25,11 +25,20 @@ b = hb.Batch(backend=sb, default_image=_config['workflow']['driver_image'])
 
 process_j = b.new_job('move-chip-output-files')
 
-FILES_TO_MOVE_LIST = [
-    f'{CROMWELL_OUTPUT_PATH}/**/*.all_variants*.csv',
-    f'{CROMWELL_OUTPUT_PATH}/**/*.exonic_splicing_variants.csv',
-    f'{CROMWELL_OUTPUT_PATH}/**/*.chip*.csv',
-]
+FILES_TO_MOVE_LIST = []
+
+if _config['analyses'].get('chip', False):
+    FILES_TO_MOVE_LIST.extend([
+        f'{CROMWELL_OUTPUT_PATH}/**/*.all_variants*.csv',
+        f'{CROMWELL_OUTPUT_PATH}/**/*.exonic_splicing_variants.csv',
+        f'{CROMWELL_OUTPUT_PATH}/**/*.chip*.csv',
+    ])
+if _config['analyses'].get('annovar', False):
+    FILES_TO_MOVE_LIST.extend([
+        f'{CROMWELL_OUTPUT_PATH}/**/*.hg38_multianno.vcf',
+        f'{CROMWELL_OUTPUT_PATH}/**/*.hg38_multianno.txt',
+    ])
+
 FILES_TO_MOVE = ' '.join(FILES_TO_MOVE_LIST)
 
 process_j.command(f"gcloud -q auth activate-service-account --key-file=/gsa-key/key.json; gsutil mv {FILES_TO_MOVE} {OUTPUT_PATH}")


### PR DESCRIPTION
Just adding another set of analysis outputs (annovar annotations) we may need to move to the analysis bucket after running the pipeline.