### PR TITLE
fix config read loop

### DIFF
--- a/scripts/cpg_cromwell/full.submit.py
+++ b/scripts/cpg_cromwell/full.submit.py
@@ -82,7 +82,7 @@ input_prefix = 'Mutect2CHIP'
 
 input_dict = {
     f'{input_prefix}.{k}': v
-    for k, v in _config['mutect2_chip']
+    for k, v in _config['mutect2_chip'].items()
 }
 
 submit_j, workflow_id_file = submit_cromwell_workflow(


### PR DESCRIPTION
Found a bug when reading in configuration details from TOML config. Fixed by adding `.items()` to extract key:value pairs from mutect2-chip dictionary