### PR TITLE
Add cpg_workflows image to data mover scripts

### DIFF
--- a/scripts/cpg_cromwell/export_analysis_outs.py
+++ b/scripts/cpg_cromwell/export_analysis_outs.py
@@ -3,7 +3,7 @@ Move the CHIP pipeline outputs to the release bucket for export to the GML priva
 """
 import hailtop.batch as hb
 from cpg_utils.config import get_config
-from cpg_utils.hail_batch import remote_tmpdir, get_batch
+from cpg_utils.hail_batch import get_batch, image_path
 
 import re
 
@@ -47,7 +47,7 @@ if not re.match(r'^gs://[A-Za-z0-9\-_\/\.]+$', OUTPUT_PATH):
 b = get_batch()
 
 process_j = b.new_job('move-chip-output-files')
-
+process_j.image(image_path('cpg_workflows'))
 process_j.command(f"gcloud -q auth activate-service-account --key-file=/gsa-key/key.json; gsutil mv {CROMWELL_OUTPUT_PATH} {OUTPUT_PATH}")
 
 b.run(wait=False)

--- a/scripts/cpg_cromwell/remove_analysis_outs.py
+++ b/scripts/cpg_cromwell/remove_analysis_outs.py
@@ -3,7 +3,7 @@ Remove the CHIP pipeline outputs from the release bucket once no longer needed
 """
 import hailtop.batch as hb
 from cpg_utils.config import get_config
-from cpg_utils.hail_batch import remote_tmpdir, get_batch
+from cpg_utils.hail_batch import get_batch, image_path
 
 import re
 
@@ -44,7 +44,7 @@ if not re.match(r'^gs://[A-Za-z0-9\-_\/\.]+$', OUTPUT_PATH):
 b = get_batch()
 
 process_j = b.new_job('move-chip-output-files')
-
+process_j.image(image_path('cpg_workflows'))
 process_j.command(f"gcloud -q auth activate-service-account --key-file=/gsa-key/key.json; gsutil rm -r {OUTPUT_PATH}")
 
 b.run(wait=False)


### PR DESCRIPTION
We need to have use cpg_workflows image when moving the data from the main bucket to release/analysis. I have added the image() directive to do this.

I also updated `move_analysis_outs.py` to sanitise the paths as we did with the other mover scripts.